### PR TITLE
Added Bao and Staudt to reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,10 @@ updates:
   target-branch: main
   reviewers:
   - t-ober
-  - sensarmad
+  - jo-bao
   - sebastian-peter
   - danielfeismann
+  - staudtMarius
   ignore:
     - dependency-name: org.scalatest:scalatest_2.13
       versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - Allow parsing of PSDM `EvInputs` [#112](https://github.com/ie3-institute/MobilitySimulator/issues/112)
+- Added Bao and Staudt as Reviewers [#299](https://github.com/ie3-institute/MobilitySimulator/issues/299)
 
 ### Changed
 - Changed sets of evs from sorted to unsorted [#113](https://github.com/ie3-institute/MobilitySimulator/issues/113)


### PR DESCRIPTION
This pull request includes changes to update the list of reviewers in the `.github/dependabot.yml` file and document these additions in the `CHANGELOG.md`.

Updates to reviewers:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R15): Replaced `sensarmad` with `jo-bao` and added `staudtMarius` to the list of reviewers.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11): Added an entry noting the addition of Bao and Staudt as reviewers.