### PR TITLE
Unify Simona Output Directory

### DIFF
--- a/src/main/scala/edu/ie3/mobsim/MobilitySimulator.scala
+++ b/src/main/scala/edu/ie3/mobsim/MobilitySimulator.scala
@@ -592,6 +592,18 @@ object MobilitySimulator
     logger.debug("Parsing config")
     val config = ArgsParser
       .prepareConfig(getMainArgs)
+      .map { cfg =>
+        // Set the output directory to /output if not already set
+        val updatedOutputDir = if (cfg.mobsim.output.outputDir.isEmpty) {
+          "/output"
+        } else {
+          cfg.mobsim.output.outputDir
+        }
+        cfg.copy(mobsim =
+          cfg.mobsim
+            .copy(output = cfg.mobsim.output.copy(outputDir = updatedOutputDir))
+        )
+      }
       .getOrElse(
         throw InitializationException(
           s"Unable to parse config from given args '${getMainArgs

--- a/src/main/scala/edu/ie3/mobsim/MobilitySimulator.scala
+++ b/src/main/scala/edu/ie3/mobsim/MobilitySimulator.scala
@@ -595,7 +595,7 @@ object MobilitySimulator
       .map { cfg =>
         // Set the output directory to /output if not already set
         val updatedOutputDir = if (cfg.mobsim.output.outputDir.isEmpty) {
-          "/output"
+          Some("/output")
         } else {
           cfg.mobsim.output.outputDir
         }

--- a/src/main/scala/edu/ie3/mobsim/io/geodata/HomePoiMapping.scala
+++ b/src/main/scala/edu/ie3/mobsim/io/geodata/HomePoiMapping.scala
@@ -29,7 +29,11 @@ object HomePoiMapping {
   }
 
   implicit val uuids: CellDecoder[Seq[UUID]] = CellDecoder.from((s: String) => {
-    val triedUuids = s.split(" ").map(uuid => Try(UUID.fromString(uuid))).toSeq
+    val triedUuids = s
+      .split(" ")
+      .filter(_.nonEmpty)
+      .map(uuid => Try(UUID.fromString(uuid)))
+      .toSeq
     triedUuids.partitionMap(_.toEither) match {
       case (Nil, uuids) => Right(uuids)
       case (errors, _) =>


### PR DESCRIPTION
This pull request includes several changes to improve error handling and logging in the `MobilitySimulator` and related components. The most important changes include updating the output directory configuration, improving UUID parsing, adding logging, and enhancing error handling.

### Configuration and Parsing Improvements:

* [`src/main/scala/edu/ie3/mobsim/MobilitySimulator.scala`](diffhunk://#diff-bdd6493edb98b016818b2935070394b8b9db6885e1600c0f92370597e3914744R595-R606): Set the output directory to `/output` if not already set in the configuration.
* [`src/main/scala/edu/ie3/mobsim/io/geodata/HomePoiMapping.scala`](diffhunk://#diff-566dc525035f76e325962b89ac780993ca4dcb7970e33a078a83f9fa0996e3ceL32-R36): Filter out empty strings when parsing UUIDs to avoid errors.

### Logging Enhancements:

* [`src/main/scala/edu/ie3/mobsim/model/builder/EvBuilderFromEvInputWithEvcsMapping.scala`](diffhunk://#diff-f9ee1f559a6515dd4740b322b3badd289a676a1102bc67f83746f27ec9db6db3R18-R25): Added a logger to the `EvBuilderFromEvInputWithEvcsMapping` object for improved logging.

### Error Handling Improvements:

* [`src/main/scala/edu/ie3/mobsim/model/builder/EvBuilderFromEvInputWithEvcsMapping.scala`](diffhunk://#diff-f9ee1f559a6515dd4740b322b3badd289a676a1102bc67f83746f27ec9db6db3L99-R103): Enhanced error handling by using pattern matching to handle missing `homePoi` and `evcs` entries, and logging warnings instead of throwing exceptions. [[1]](diffhunk://#diff-f9ee1f559a6515dd4740b322b3badd289a676a1102bc67f83746f27ec9db6db3L99-R103) [[2]](diffhunk://#diff-f9ee1f559a6515dd4740b322b3badd289a676a1102bc67f83746f27ec9db6db3R117-L129) [[3]](diffhunk://#diff-f9ee1f559a6515dd4740b322b3badd289a676a1102bc67f83746f27ec9db6db3L144-R156)