### PR TITLE
Fixed version check logic for dependabot PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed exception messages of probability factories [#263](https://github.com/ie3-institute/MobilitySimulator/issues/263)
 - MobSim sends arrivals for unexpected tick to SIMONA [#316](https://github.com/ie3-institute/MobilitySimulator/issues/316)
 - Fixed movement writer [#363](https://github.com/ie3-institute/MobilitySimulator/issues/363)
-
+- Fixed version check for dependabot PRs [#375](https://github.com/ie3-institute/MobilitySimulator/issues/375)
 [Unreleased]: https://github.com/ie3-institute/MobilitySimulator

--- a/scripts/version_check.sh
+++ b/scripts/version_check.sh
@@ -39,7 +39,8 @@ semver_gt() {
 # Version Checking Logic
 if [ "$BASE_BRANCH" = "main" ]; then
   echo "'$BRANCH_TYPE' branch into main => applying '$BRANCH_TYPE' rules"
-  if [ "$PR_VERSION" = "$MAIN_VERSION" ] && [ "$BRANCH_TYPE" = "feature" ]; then
+  if [ "$PR_VERSION" = "$MAIN_VERSION" ] && \
+        { [ "$BRANCH_TYPE" = "feature" ] || [ "$BRANCH_TYPE" = "dependabot" ]; }; then
     echo "OK: PR Version ($PR_VERSION) is identical with the current Main version ($MAIN_VERSION)."
     exit 0
   elif semver_gt "$PR_VERSION" "$MAIN_VERSION" && [ "$BRANCH_TYPE" = "release" ]; then


### PR DESCRIPTION
Closes #375 
This pull request addresses a bug in the version checking logic for dependabot pull requests and updates the changelog to reflect the fix.

Bug fix for version checking:

* [`scripts/version_check.sh`](diffhunk://#diff-bac2665431f40a52c4e46a07da5ffea08ca73d50a04bb5db54a700c1feb00b5dL42-R43): Updated the `semver_gt` function to include a check for `dependabot` branch type, ensuring that dependabot pull requests with identical versions to the main branch are correctly handled.

Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL40-R40): Added an entry for fixing the version check for dependabot pull requests.